### PR TITLE
Allow non-ASCII characters from calling JS code

### DIFF
--- a/EventLog/EventLog.cpp
+++ b/EventLog/EventLog.cpp
@@ -59,9 +59,7 @@ public:
 	
 	static inline gcroot<System::String^> ParseArgument(Arguments const&args, int argumentIndex)
 	{
-		Local<String> message = Local<String>::Cast(args[argumentIndex]);
-		gcroot<System::String^> m = gcnew System::String(((std::string)*v8::String::AsciiValue(message)).c_str());
-		return m;
+		return gcnew System::String((const wchar_t *) *v8::String::Value(args[argumentIndex]));
 	}
 
     static Handle<Value> New(const Arguments& args)


### PR DESCRIPTION
JS strings are UTF-16 encoded and can be passed into the System::String(char\* value) constructor directly.
