### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 var fs = require('fs');
+var path = require('path');
 
-if(fs.existsSync('build/release/EventLog.node')) {
-  module.exports = require('./build/release/EventLog.node');
+var gypRequirePathname = './build/Release/EventLog.node';
+if (fs.existsSync(path.normalize(module.filename + '/../' + gypRequirePathname))) {
+  module.exports = require(gypRequirePathname);
 } else {
   module.exports = require('./prebuild/' + process.arch + '/EventLog.node');
 }


### PR DESCRIPTION
Fix an issue with the module load in index.js in which the check for any recently gyp-compiled node module would never succeed (due to using an invalid relative path in the fs.existSync function call).
